### PR TITLE
[docs] Fix missing end of code block

### DIFF
--- a/prerequisites.md
+++ b/prerequisites.md
@@ -23,7 +23,7 @@ ibmcloud login --sso
 ibmcloud target -g <YOUR RG> -r <YOUR IBM CLOUD REGION>
 # reset the API Key
 ibmcloud ks api-key reset --region <YOUR IBM CLOUD REGION>
-
+```
 
 ## Create an IAM Service ID for OpenShift Data Foundation (ODF)
 * Create an IAM Service ID "odf-local"


### PR DESCRIPTION
Add the missing end of a code block to have the remainder of the documentation properly rendered and show the included images.