### PR TITLE
force version 13 of mas_devops

### DIFF
--- a/Dockerfile.olm-utils
+++ b/Dockerfile.olm-utils
@@ -20,7 +20,8 @@ RUN yum install -y yum-utils python39 python39-pip && \
 
 RUN pip3 install ansible
 
-RUN ansible-galaxy collection install community.general community.crypto ansible.utils community.vmware kubernetes.core ibm.mas_devops
+RUN ansible-galaxy collection install community.general community.crypto ansible.utils community.vmware kubernetes.core
+RUN ansible-galaxy collection install ibm.mas_devops:13.15.1
 
 VOLUME ["/Data"]
 


### PR DESCRIPTION
version 14 uses ibmcloud plugin CIS which is not available on Linux aarch64